### PR TITLE
Implement serialize, update tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/crate/pythonize/"
 
 [dependencies]
 serde = { version = "1.0" }
-pyo3 = { version = "0.11.1", default-features = false }
+pyo3 = { version = "0.12.1", default-features = false }
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Updates to the latest pyo3, implements `Serialize` and updates tests to account for it.

This is a pretty small change set, but I'm a relatively new Rust developer so it's possible I'm doing silly things. Feedback quite welcome.

This has seen active use in one of my own projects, adapting [this project](https://gitlab.com/rubidium-dev/powers) to serialize its output into Python dicts. Originally I approached this with [dict-derive](https://github.com/gperinazzo/dict-derive), but serde's control over field attributes and serialization paths was much more effective.  Without that level of control, repeated reference counted fields were being re-serialized to Python many thousands of times. I could have created stripped-down copies of the structs I was after and serialized those instead, but using serde eliminates the need to maintain two sets of structs as things evolve.

I didn't _need_ to implement `Deserialize` so I haven't yet, but I _could_ use it in my project, so I might yet take a stab. If I do, I'll PR that as well.