### PR TITLE
ser: cleanup tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,5 @@ pyo3 = { version = "0.12", default-features = false }
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }
-paste = "1.0"
 serde_json = "1.0"
 maplit = "1.0.2"


### PR DESCRIPTION
Removes the macro to follow a similar strategy to `de.rs`.