### PR TITLE
fix deserialize_any for dict keys; fix pytuple deserialization 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pythonize"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["David Hewitt <1939362+davidhewitt@users.noreply.github.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/de.rs
+++ b/src/de.rs
@@ -604,23 +604,45 @@ mod test {
         let code = "{'Struct': {'foo': 'cat', 'bar': 25}}";
         test_de(code, &expected);
     }
+    #[test]
+    fn test_enum_untagged_tuple_variant() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        #[serde(untagged)]
+        enum Foo {
+            Tuple(f32, char),
+        }
+
+        let expected = Foo::Tuple(12.0, 'c');
+        let code = "[12.0, 'c']";
+        test_de(code, &expected);
+    }
+
+    #[test]
+    fn test_enum_untagged_newtype_variant() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        #[serde(untagged)]
+        enum Foo {
+            NewType(String),
+        }
+
+        let expected = Foo::NewType("cat".to_string());
+        let code = "'cat'";
+        test_de(code, &expected);
+    }
 
     #[test]
     fn test_enum_untagged_struct_variant() {
         #[derive(Debug, Deserialize, PartialEq)]
         #[serde(untagged)]
         enum Foo {
-            Bar(Bar),
+            Struct { foo: String, bar: i32 },
         }
 
-        #[derive(Debug, Deserialize, PartialEq)]
-        struct Bar {
-            val1: i64,
-            val2: i64,
-        }
-
-        let expected = Foo::Bar(Bar { val1: 4, val2: 100 });
-        let code = "{'val1': 4, 'val2': 100}";
+        let expected = Foo::Struct {
+            foo: "cat".to_string(),
+            bar: -25,
+        };
+        let code = "{'foo': 'cat', 'bar': -25}";
         test_de(code, &expected);
     }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -40,17 +40,13 @@ impl<'de> Depythonizer<'de> {
 
     fn get_item(&self) -> Result<Option<&'de PyAny>> {
         match self.current {
-            GetItemKey::Key(k) => {
-                let dict: &PyDict = self.input.cast_as()?;
-                Ok(dict.get_item(&k))
-            }
+            GetItemKey::Key(k) => Ok(Some(self.input.get_item(&k)?)),
             GetItemKey::Index(i) => {
-                let list: &PyList = self.input.cast_as()?;
-                let len = list.len() as isize;
+                let len = self.input.len()? as isize;
                 if (i >= len) || (i < -len) {
                     Ok(None)
                 } else {
-                    Ok(Some(list.get_item(i)))
+                    Ok(Some(self.input.get_item(i)?))
                 }
             }
             GetItemKey::None => Ok(Some(self.input)),
@@ -529,12 +525,19 @@ mod test {
         struct TupleStruct(String, f64);
 
         let expected = TupleStruct("cat".to_string(), -10.05);
-        let code = "['cat', -10.05]";
+        let code = "('cat', -10.05)";
         test_de(code, &expected);
     }
 
     #[test]
     fn test_tuple() {
+        let expected = ("foo".to_string(), 5);
+        let code = "('foo', 5)";
+        test_de(code, &expected);
+    }
+
+    #[test]
+    fn test_tuple_from_pylist() {
         let expected = ("foo".to_string(), 5);
         let code = "['foo', 5]";
         test_de(code, &expected);

--- a/src/de.rs
+++ b/src/de.rs
@@ -530,6 +530,16 @@ mod test {
     }
 
     #[test]
+    fn test_tuple_struct_from_pylist() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct TupleStruct(String, f64);
+
+        let expected = TupleStruct("cat".to_string(), -10.05);
+        let code = "['cat', -10.05]";
+        test_de(code, &expected);
+    }
+
+    #[test]
     fn test_tuple() {
         let expected = ("foo".to_string(), 5);
         let code = "('foo', 5)";
@@ -547,6 +557,13 @@ mod test {
     fn test_vec() {
         let expected = vec![3, 2, 1];
         let code = "[3, 2, 1]";
+        test_de(code, &expected);
+    }
+
+    #[test]
+    fn test_vec_from_tuple() {
+        let expected = vec![3, 2, 1];
+        let code = "(3, 2, 1)";
         test_de(code, &expected);
     }
 
@@ -638,14 +655,14 @@ mod test {
         #[derive(Debug, Deserialize, PartialEq)]
         #[serde(untagged)]
         enum Foo {
-            Struct { foo: String, bar: i32 },
+            Struct { foo: Vec<char>, bar: [u8; 4] },
         }
 
         let expected = Foo::Struct {
-            foo: "cat".to_string(),
-            bar: -25,
+            foo: vec!['a', 'b', 'c'],
+            bar: [2, 5, 3, 1],
         };
-        let code = "{'foo': 'cat', 'bar': -25}";
+        let code = "{'foo': ['a', 'b', 'c'], 'bar': [2, 5, 3, 1]}";
         test_de(code, &expected);
     }
 


### PR DESCRIPTION
* Fixes dict keys not being properly handled in `deserialize_any` (and instead the value was being deserialized twice). This caused untagged struct enum variants to fail deserialization. 
* Fixed deserializing seq values from python tuples due to an unnecessary cast to PyList