### PR TITLE
deps: require `std` feature of serde

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+ - Require `std` feature of `serde`.
+
 ## 0.12.0 - 2020-11-22
 - Change release versioning to match `pyo3` major/minor version.
 - Implement `depythonizer`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ documentation = "https://docs.rs/crate/pythonize/"
 
 
 [dependencies]
-serde = { version = "1.0", default-features = false }
+serde = { version = "1.0", default-features = false, features = ["std"] }
 pyo3 = { version = "0.12", default-features = false }
 
 [dev-dependencies]
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1.0"
 maplit = "1.0.2"


### PR DESCRIPTION
Closes #8 

The `collect_str` implementation is required if neither of the `std` or `alloc` features of `serde` are enabled.

I think it's reasonable for `pythonize` to require the `std` feature, as `pyo3` does not yet work in `#![no_std]` environments.