### PR TITLE
finish support for custom types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false  # If one platform fails, allow the rest to keep testing.
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
         platform: [
           { os: "macOS-latest",   python-architecture: "x64", rust-target: "x86_64-apple-darwin" },
           { os: "ubuntu-latest", python-architecture: "x64", rust-target: "x86_64-unknown-linux-gnu" },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Add `pythonize_custom` for customizing the Python types to serialize to.
+- Add support for `depythonize` to handle arbitrary Python sequence and mapping types.
+
 ## 0.14.0 - 2021-07-05
 
 - Update to PyO3 0.14

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ pyo3 = { git = "https://github.com/PyO3/pyo3", rev = "4ea03a3159401a91de7042726f
 
 [dev-dependencies]
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-pyo3 = { git = "https://github.com/PyO3/pyo3", rev = "4ea03a3159401a91de7042726f2451317c955316", default-features = false, features = ["auto-initialize"] }
+pyo3 = { git = "https://github.com/PyO3/pyo3", rev = "4ea03a3159401a91de7042726f2451317c955316", default-features = false, features = ["auto-initialize", "macros"] }
 serde_json = "1.0"
 maplit = "1.0.2"

--- a/src/de.rs
+++ b/src/de.rs
@@ -85,6 +85,10 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Depythonizer<'de> {
             self.deserialize_tuple(obj.len()?, visitor)
         } else if obj.is_instance::<PyUnicode>()? {
             self.deserialize_str(visitor)
+        } else if let Ok(seq) = obj.downcast::<PySequence>() {
+            self.deserialize_tuple(seq.len()?, visitor)
+        } else if obj.downcast::<PyMapping>().is_ok() {
+            self.deserialize_map(visitor)
         } else {
             Err(PythonizeError::unsupported_type(
                 obj.get_type().name().unwrap_or("<unknown>"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,4 +42,6 @@ mod ser;
 
 pub use crate::de::depythonize;
 pub use crate::error::{PythonizeError, Result};
-pub use crate::ser::{pythonize, pythonize_custom, AsPyMapping, AsPySequence, PythonizeTypes};
+pub use crate::ser::{
+    pythonize, pythonize_custom, PythonizeDictType, PythonizeListType, PythonizeTypes,
+};

--- a/tests/test_custom_types.rs
+++ b/tests/test_custom_types.rs
@@ -1,0 +1,142 @@
+use std::collections::HashMap;
+
+use pyo3::{
+    exceptions::{PyIndexError, PyKeyError},
+    prelude::*,
+    types::{PyDict, PyList, PyMapping, PySequence},
+    PyMappingProtocol, PySequenceProtocol,
+};
+use pythonize::{
+    depythonize, pythonize_custom, PythonizeDictType, PythonizeListType, PythonizeTypes,
+};
+use serde_json::{json, Value};
+
+#[pyclass]
+struct CustomList {
+    items: Vec<PyObject>,
+}
+
+#[pyproto]
+impl PySequenceProtocol for CustomList {
+    fn __len__(&self) -> usize {
+        self.items.len()
+    }
+
+    fn __getitem__(&self, idx: isize) -> PyResult<PyObject> {
+        self.items
+            .get(idx as usize)
+            .cloned()
+            .ok_or_else(|| PyIndexError::new_err(idx))
+    }
+}
+
+impl PythonizeListType for CustomList {
+    fn create_sequence<T, U>(
+        py: Python,
+        elements: impl IntoIterator<Item = T, IntoIter = U>,
+    ) -> PyResult<&PySequence>
+    where
+        T: ToPyObject,
+        U: ExactSizeIterator<Item = T>,
+    {
+        let sequence = Py::new(
+            py,
+            CustomList {
+                items: elements
+                    .into_iter()
+                    .map(|item| item.to_object(py))
+                    .collect(),
+            },
+        )?
+        .into_ref(py)
+        .downcast()?;
+        Ok(sequence)
+    }
+}
+
+struct PythonizeCustomList;
+impl PythonizeTypes for PythonizeCustomList {
+    type Map = PyDict;
+    type List = CustomList;
+}
+
+#[test]
+fn test_custom_list() {
+    Python::with_gil(|py| {
+        let serialized = pythonize_custom::<PythonizeCustomList, _>(py, &json!([1, 2, 3]))
+            .unwrap()
+            .into_ref(py);
+        assert!(serialized.is_instance::<CustomList>().unwrap());
+
+        let deserialized: Value = depythonize(serialized).unwrap();
+        assert_eq!(deserialized, json!([1, 2, 3]));
+    })
+}
+
+#[pyclass]
+struct CustomDict {
+    items: HashMap<String, PyObject>,
+}
+
+#[pyproto]
+impl PyMappingProtocol for CustomDict {
+    fn __len__(&self) -> usize {
+        self.items.len()
+    }
+
+    fn __getitem__(&self, key: String) -> PyResult<PyObject> {
+        self.items
+            .get(&key)
+            .cloned()
+            .ok_or_else(|| PyKeyError::new_err(key))
+    }
+
+    fn __setitem__(&mut self, key: String, value: PyObject) {
+        self.items.insert(key, value);
+    }
+}
+
+#[pymethods]
+impl CustomDict {
+    fn keys(&self) -> Vec<&String> {
+        self.items.keys().collect()
+    }
+
+    fn values(&self) -> Vec<PyObject> {
+        self.items.values().cloned().collect()
+    }
+}
+
+impl PythonizeDictType for CustomDict {
+    fn create_mapping(py: Python) -> PyResult<&PyMapping> {
+        let mapping = Py::new(
+            py,
+            CustomDict {
+                items: HashMap::new(),
+            },
+        )?
+        .into_ref(py)
+        .downcast()?;
+        Ok(mapping)
+    }
+}
+
+struct PythonizeCustomDict;
+impl PythonizeTypes for PythonizeCustomDict {
+    type Map = CustomDict;
+    type List = PyList;
+}
+
+#[test]
+fn test_custom_dict() {
+    Python::with_gil(|py| {
+        let serialized =
+            pythonize_custom::<PythonizeCustomDict, _>(py, &json!({ "hello": 1, "world": 2 }))
+                .unwrap()
+                .into_ref(py);
+        assert!(serialized.is_instance::<CustomDict>().unwrap());
+
+        let deserialized: Value = depythonize(serialized).unwrap();
+        assert_eq!(deserialized, json!({ "hello": 1, "world": 2 }));
+    })
+}


### PR DESCRIPTION
This PR simplifies the traits for serializing custom types. It also adds support for deserializing them (and a test).

cc @i1i1 it would be great if you are willing to try this branch out.