### PR TITLE
fix: use upstream pyo3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,10 @@ documentation = "https://docs.rs/crate/pythonize/"
 
 [dependencies]
 serde = { version = "1.0", default-features = false, features = ["std"] }
-pyo3 = { git = "https://github.com/PyO3/pyo3", rev = "4ea03a3159401a91de7042726f2451317c955316", default-features = false }
+pyo3 = { version = "0.15.0", default-features = false }
 
 [dev-dependencies]
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-pyo3 = { git = "https://github.com/PyO3/pyo3", rev = "4ea03a3159401a91de7042726f2451317c955316", default-features = false, features = ["auto-initialize", "macros"] }
+pyo3 = { version = "0.15.0", default-features = false, features = ["auto-initialize", "macros"] }
 serde_json = "1.0"
 maplit = "1.0.2"


### PR DESCRIPTION
PyO3 `0.15.0` was release 9 days ago.

This PR uses the upstream crate from crates.io instead of the git verion. Any need for the git?

Since 0.15.0 broke some typing namespacing this is a neede change for all developers using PyO3 and pythonize which do not like to hack their way to the working code.

Quickly ran the tests, none of them failed