### PR TITLE
Expose the Pythonizer and Depythonizer

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -13,11 +13,13 @@ where
     T::deserialize(&mut depythonizer)
 }
 
+/// A structure that deserializes Python objects into Rust values
 pub struct Depythonizer<'de> {
     input: &'de PyAny,
 }
 
 impl<'de> Depythonizer<'de> {
+    /// Create a deserializer from a Python object
     pub fn from_object(input: &'de PyAny) -> Self {
         Depythonizer { input }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,8 +40,8 @@ mod de;
 mod error;
 mod ser;
 
-pub use crate::de::depythonize;
+pub use crate::de::{depythonize, Depythonizer};
 pub use crate::error::{PythonizeError, Result};
 pub use crate::ser::{
-    pythonize, pythonize_custom, PythonizeDictType, PythonizeListType, PythonizeTypes,
+    pythonize, pythonize_custom, PythonizeDictType, PythonizeListType, PythonizeTypes, Pythonizer,
 };


### PR DESCRIPTION
This exposes the Pythonizer and Depythonizer structs, adding documentation to them and to their public methods.
It also adds methods to create a Pythonizer.

Fixes #30 