### PR TITLE
Add depythonize_on_error

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -76,8 +76,6 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Depythonizer<'de> {
             self.deserialize_unit(visitor)
         } else if obj.is_instance_of::<PyBool>()? {
             self.deserialize_bool(visitor)
-        } else if obj.is_instance_of::<PyByteArray>()? || obj.is_instance_of::<PyBytes>()? {
-            self.deserialize_bytes(visitor)
         } else if obj.is_instance_of::<PyDict>()? {
             self.deserialize_map(visitor)
         } else if obj.is_instance_of::<PyFloat>()? {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ mod de;
 mod error;
 mod ser;
 
-pub use crate::de::depythonize;
+pub use crate::de::{depythonize, depythonize_on_error};
 pub use crate::error::{PythonizeError, Result};
 pub use crate::ser::{
     pythonize, pythonize_custom, PythonizeDictType, PythonizeListType, PythonizeTypes,


### PR DESCRIPTION
I'm opening this PR more as a place to start a discussion for my use-case and the changes I needed to make to support it. I'm hoping it's possible to turn this into a feature that's more broadly useful to other users.

My use case is I'm building a profiler/debugger called Kolo (https://kolo.app/). As part of this we have a Python library which inspects Python frame objects and serializes information about them (such as local variables) as json. In this I make use of a custom [`JSONEncoder`](https://docs.python.org/3/library/json.html#json.JSONEncoder) to serialize otherwise unserializable data (as their `repr`).

I have been reimplementing this library in Rust for performance, and json encoding is a measurable slowdown in my profiling, so I'm trying to use `pythonize` and `serde_json` to avoid calling Python's `json.dumps`.

With the changes in this branch, and the following implementation of a `dump_json` function my tests all pass:

```rust
use pyo3::intern;
use pyo3::prelude::*;
use pythonize::depythonize_on_error;
use serde_json::Value;

fn on_error(data: &PyAny) -> &PyAny {
    let py = data.py();
    match data.repr() {
        Ok(repr) => repr,
        Err(_) => intern!(py, "SerializationError"),
    }
}

pub fn dump_json(py: Python, data: &PyAny) -> Result<Value, PyErr> {
    let data: Value = depythonize_on_error(data, &Some(on_error))?;
    Ok(data)
}
```

Is a feature allowing some fallback behaviour on errors desirable for this library? Or is there a better way to achieve what I'm trying to do?