### PR TITLE
Fix deserializing `set` and `frozenset`.

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -559,6 +559,22 @@ mod test {
     }
 
     #[test]
+    fn test_tuple_from_pyset() {
+        let expected = ("foo".to_string(), 5);
+        let expected_json = json!(["foo", 5]);
+        let code = "{'foo', 5}";
+        test_de(code, &expected, &expected_json);
+    }
+
+    #[test]
+    fn test_tuple_from_pyfrozenset() {
+        let expected = ("foo".to_string(), 5);
+        let expected_json = json!(["foo", 5]);
+        let code = "frozenset({'foo', 5})";
+        test_de(code, &expected, &expected_json);
+    }
+
+    #[test]
     fn test_vec() {
         let expected = vec![3, 2, 1];
         let expected_json = json!([3, 2, 1]);


### PR DESCRIPTION
Adding these tests shows the following errors:

```
failures:

---- de::test::test_tuple_from_pyfrozenset stdout ----
thread 'de::test::test_tuple_from_pyfrozenset' panicked at 'called `Result::unwrap()` on an `Err` value: UnexpectedType("'frozenset' object cannot be converted to 'Sequence'")', src/de.rs:441:46
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- de::test::test_tuple_from_pyset stdout ----
thread 'de::test::test_tuple_from_pyset' panicked at 'called `Result::unwrap()` on an `Err` value: UnexpectedType("'set' object cannot be converted to 'Sequence'")', src/de.rs:441:46


failures:
    de::test::test_tuple_from_pyfrozenset
    de::test::test_tuple_from_pyset
```