### PR TITLE
Relax input requirements in deserialize_str

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 pyo3 = { version = "0.18.0", default-features = false, features = ["auto-initialize", "macros"] }
 serde_json = "1.0"
 maplit = "1.0.2"
+uuid = { version = "1.3.0", features = ["serde", "v4"]}


### PR DESCRIPTION
Instead of attempting to downcast the input to a PyString, rely on the fact that for str objects, calling __str__ is a no-op, while for other objects it may allow us to support neat use cases.

An example of one such use case is turning Python's uuid.UUID into Rust's uuid::Uuid. If you call Uuid::depythonize you end up in <Uuid as Deserialize>::deserialize (if you enabled its serde feature). Since Depythonizer doesn't override Deserialize::is_human_readable, the implementation tries to deserialize with deserialize_str. At that point, the Deserializer has a value of type uuid.UUID (actually PyAny, but it really is uuid.UUID), and the visitor expects a value of type &str. We can make that happen by using __str__.