### PR TITLE
Support serialising to named mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `Depythonizer` now contains a `&Bound` and so has an extra lifetime `'bound`
 - `Depythonizer::from_object()` now takes a `&Bound` and is no longer deprecated
 - Fix overflow error attempting to depythonize `u64` values greater than `i64::MAX` to types like `serde_json::Value`
+- Support serializing struct-like types to named mappings using `PythonizeTypes::NamedMap`
 
 ## 0.21.1 - 2024-04-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - `Depythonizer` now contains a `&Bound` and so has an extra lifetime `'bound`
 - `Depythonizer::from_object()` now takes a `&Bound` and is no longer deprecated
 - Fix overflow error attempting to depythonize `u64` values greater than `i64::MAX` to types like `serde_json::Value`
+- Implement `PythonizeListType` for `PyTuple`
+- Support deserializing enums from any `PyMapping` instead of just `PyDict`
 - Support serializing struct-like types to named mappings using `PythonizeTypes::NamedMap`
 
 ## 0.21.1 - 2024-04-02

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,5 +46,5 @@ pub use crate::de::{depythonize, Depythonizer};
 pub use crate::error::{PythonizeError, Result};
 pub use crate::ser::{
     pythonize, pythonize_custom, PythonizeDefault, PythonizeListType, PythonizeMappingType,
-    PythonizeNamedMappingType, PythonizeTypes, PythonizeUnnamedMappingWrapper, Pythonizer,
+    PythonizeNamedMappingType, PythonizeTypes, PythonizeUnnamedMappingAdapter, Pythonizer,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,6 @@ pub use crate::de::depythonize_bound;
 pub use crate::de::{depythonize, Depythonizer};
 pub use crate::error::{PythonizeError, Result};
 pub use crate::ser::{
-    pythonize, pythonize_custom, MappingBuilder, PythonizeDefault, PythonizeListType,
-    PythonizeMappingType, PythonizeNamedMappingType, PythonizeTypes, Pythonizer,
+    pythonize, pythonize_custom, PythonizeDefault, PythonizeListType, PythonizeMappingType,
+    PythonizeNamedMappingType, PythonizeTypes, PythonizeUnnamedMappingWrapper, Pythonizer,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,6 @@ pub use crate::de::depythonize_bound;
 pub use crate::de::{depythonize, Depythonizer};
 pub use crate::error::{PythonizeError, Result};
 pub use crate::ser::{
-    pythonize, pythonize_custom, PythonizeDefault, PythonizeDictType, PythonizeListType,
-    PythonizeTypes, Pythonizer,
+    pythonize, pythonize_custom, MappingBuilder, PythonizeDefault, PythonizeListType,
+    PythonizeMappingType, PythonizeNamedMappingType, PythonizeTypes, Pythonizer,
 };

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -54,6 +54,19 @@ impl PythonizeListType for PyList {
     }
 }
 
+impl PythonizeListType for PyTuple {
+    fn create_sequence<T, U>(
+        py: Python,
+        elements: impl IntoIterator<Item = T, IntoIter = U>,
+    ) -> PyResult<Bound<PySequence>>
+    where
+        T: ToPyObject,
+        U: ExactSizeIterator<Item = T>,
+    {
+        Ok(PyTuple::new_bound(py, elements).into_sequence())
+    }
+}
+
 pub struct PythonizeDefault;
 
 impl PythonizeTypes for PythonizeDefault {

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -104,26 +104,6 @@ pub struct PythonizeUnnamedMappingAdapter<'py, T: PythonizeMappingType<'py>> {
     _marker: PhantomData<&'py ()>,
 }
 
-impl<'py, T: PythonizeMappingType<'py>> PythonizeUnnamedMappingAdapter<'py, T> {
-    #[must_use]
-    pub fn new(unnamed: T) -> Self {
-        Self {
-            unnamed,
-            _marker: PhantomData::<&'py ()>,
-        }
-    }
-
-    #[must_use]
-    pub fn into_inner(self) -> T {
-        self.unnamed
-    }
-}
-
-impl<'py, T: PythonizeMappingType<'py>> From<T> for PythonizeUnnamedMappingAdapter<'py, T> {
-    fn from(value: T) -> Self {
-        Self::new(value)
-    }
-}
 
 impl<'py, T: PythonizeMappingType<'py>> PythonizeNamedMappingType<'py>
     for PythonizeUnnamedMappingAdapter<'py, T>

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -100,10 +100,9 @@ impl<'py> PythonizeMappingType<'py> for PyDict {
 /// both [`PythonizeTypes::Map`] and [`PythonizeTypes::NamedMap`] while only
 /// implementing [`PythonizeMappingType`].
 pub struct PythonizeUnnamedMappingAdapter<'py, T: PythonizeMappingType<'py>> {
-    unnamed: T,
+    _unnamed: T,
     _marker: PhantomData<&'py ()>,
 }
-
 
 impl<'py, T: PythonizeMappingType<'py>> PythonizeNamedMappingType<'py>
     for PythonizeUnnamedMappingAdapter<'py, T>

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,6 +1,9 @@
 use std::marker::PhantomData;
 
-use pyo3::types::{PyAnyMethods, PyDict, PyList, PyMapping, PySequence, PyString, PyTuple};
+use pyo3::types::{
+    IntoPyDict, PyAnyMethods, PyDict, PyDictMethods, PyList, PyMapping, PySequence, PyString,
+    PyTuple, PyTupleMethods,
+};
 use pyo3::{Bound, IntoPy, PyAny, PyResult, Python, ToPyObject};
 use serde::{ser, Serialize};
 
@@ -10,6 +13,39 @@ use crate::error::{PythonizeError, Result};
 pub trait PythonizeDictType {
     /// Constructor
     fn create_mapping(py: Python) -> PyResult<Bound<PyMapping>>;
+
+    /// Constructor
+    fn create_mapping_with_items<
+        K: ToPyObject,
+        V: ToPyObject,
+        U: ExactSizeIterator<Item = (K, V)>,
+    >(
+        py: Python,
+        items: impl IntoIterator<Item = (K, V), IntoIter = U>,
+    ) -> PyResult<Bound<PyMapping>> {
+        let mapping = Self::create_mapping(py)?;
+
+        for (key, value) in items {
+            mapping.set_item(key, value)?;
+        }
+
+        Ok(mapping)
+    }
+
+    /// Constructor, allows the mappings to be named
+    fn create_mapping_with_items_name<
+        'py,
+        K: ToPyObject,
+        V: ToPyObject,
+        U: ExactSizeIterator<Item = (K, V)>,
+    >(
+        py: Python<'py>,
+        name: &str,
+        items: impl IntoIterator<Item = (K, V), IntoIter = U>,
+    ) -> PyResult<Bound<'py, PyMapping>> {
+        let _name = name;
+        Self::create_mapping_with_items(py, items)
+    }
 }
 
 /// Trait for types which can represent a Python sequence
@@ -35,6 +71,17 @@ pub trait PythonizeTypes {
 impl PythonizeDictType for PyDict {
     fn create_mapping(py: Python) -> PyResult<Bound<PyMapping>> {
         Ok(PyDict::new_bound(py).into_any().downcast_into().unwrap())
+    }
+
+    fn create_mapping_with_items<
+        K: ToPyObject,
+        V: ToPyObject,
+        U: ExactSizeIterator<Item = (K, V)>,
+    >(
+        py: Python,
+        items: impl IntoIterator<Item = (K, V), IntoIter = U>,
+    ) -> PyResult<Bound<PyMapping>> {
+        Ok(items.into_py_dict_bound(py).into_mapping())
     }
 }
 
@@ -129,27 +176,30 @@ pub struct PythonCollectionSerializer<'py, P> {
 
 #[doc(hidden)]
 pub struct PythonTupleVariantSerializer<'py, P> {
+    name: &'static str,
     variant: &'static str,
     inner: PythonCollectionSerializer<'py, P>,
 }
 
 #[doc(hidden)]
 pub struct PythonStructVariantSerializer<'py, P: PythonizeTypes> {
+    name: &'static str,
     variant: &'static str,
-    inner: PythonDictSerializer<'py, P>,
+    inner: PythonStructDictSerializer<'py, P>,
 }
 
 #[doc(hidden)]
-pub struct PythonDictSerializer<'py, P: PythonizeTypes> {
+pub struct PythonStructDictSerializer<'py, P: PythonizeTypes> {
     py: Python<'py>,
-    dict: Bound<'py, PyMapping>,
+    name: &'static str,
+    fields: Vec<(&'static str, Bound<'py, PyAny>)>,
     _types: PhantomData<P>,
 }
 
 #[doc(hidden)]
 pub struct PythonMapSerializer<'py, P: PythonizeTypes> {
     py: Python<'py>,
-    map: Bound<'py, PyMapping>,
+    items: Vec<(Bound<'py, PyAny>, Bound<'py, PyAny>)>,
     key: Option<Bound<'py, PyAny>>,
     _types: PhantomData<P>,
 }
@@ -162,7 +212,7 @@ impl<'py, P: PythonizeTypes> ser::Serializer for Pythonizer<'py, P> {
     type SerializeTupleStruct = PythonCollectionSerializer<'py, P>;
     type SerializeTupleVariant = PythonTupleVariantSerializer<'py, P>;
     type SerializeMap = PythonMapSerializer<'py, P>;
-    type SerializeStruct = PythonDictSerializer<'py, P>;
+    type SerializeStruct = PythonStructDictSerializer<'py, P>;
     type SerializeStructVariant = PythonStructVariantSerializer<'py, P>;
 
     fn serialize_bool(self, v: bool) -> Result<Bound<'py, PyAny>> {
@@ -262,7 +312,7 @@ impl<'py, P: PythonizeTypes> ser::Serializer for Pythonizer<'py, P> {
 
     fn serialize_newtype_variant<T>(
         self,
-        _name: &'static str,
+        name: &'static str,
         _variant_index: u32,
         variant: &'static str,
         value: &T,
@@ -270,9 +320,12 @@ impl<'py, P: PythonizeTypes> ser::Serializer for Pythonizer<'py, P> {
     where
         T: ?Sized + Serialize,
     {
-        let d = PyDict::new_bound(self.py);
-        d.set_item(variant, value.serialize(self)?)?;
-        Ok(d.into_any())
+        let m = P::Map::create_mapping_with_items_name(
+            self.py,
+            name,
+            [(variant, value.serialize(self)?)],
+        )?;
+        Ok(m.into_any())
     }
 
     fn serialize_seq(self, len: Option<usize>) -> Result<PythonCollectionSerializer<'py, P>> {
@@ -305,18 +358,22 @@ impl<'py, P: PythonizeTypes> ser::Serializer for Pythonizer<'py, P> {
 
     fn serialize_tuple_variant(
         self,
-        _name: &'static str,
+        name: &'static str,
         _variant_index: u32,
         variant: &'static str,
         len: usize,
     ) -> Result<PythonTupleVariantSerializer<'py, P>> {
         let inner = self.serialize_tuple(len)?;
-        Ok(PythonTupleVariantSerializer { variant, inner })
+        Ok(PythonTupleVariantSerializer {
+            name,
+            variant,
+            inner,
+        })
     }
 
-    fn serialize_map(self, _len: Option<usize>) -> Result<PythonMapSerializer<'py, P>> {
+    fn serialize_map(self, len: Option<usize>) -> Result<PythonMapSerializer<'py, P>> {
         Ok(PythonMapSerializer {
-            map: P::Map::create_mapping(self.py)?,
+            items: Vec::with_capacity(len.unwrap_or(0)),
             key: None,
             py: self.py,
             _types: PhantomData,
@@ -325,28 +382,31 @@ impl<'py, P: PythonizeTypes> ser::Serializer for Pythonizer<'py, P> {
 
     fn serialize_struct(
         self,
-        _name: &'static str,
-        _len: usize,
-    ) -> Result<PythonDictSerializer<'py, P>> {
-        Ok(PythonDictSerializer {
-            dict: P::Map::create_mapping(self.py)?,
+        name: &'static str,
+        len: usize,
+    ) -> Result<PythonStructDictSerializer<'py, P>> {
+        Ok(PythonStructDictSerializer {
             py: self.py,
+            name,
+            fields: Vec::with_capacity(len),
             _types: PhantomData,
         })
     }
 
     fn serialize_struct_variant(
         self,
-        _name: &'static str,
+        name: &'static str,
         _variant_index: u32,
         variant: &'static str,
-        _len: usize,
+        len: usize,
     ) -> Result<PythonStructVariantSerializer<'py, P>> {
         Ok(PythonStructVariantSerializer {
+            name,
             variant,
-            inner: PythonDictSerializer {
-                dict: P::Map::create_mapping(self.py)?,
+            inner: PythonStructDictSerializer {
                 py: self.py,
+                name: variant,
+                fields: Vec::with_capacity(len),
                 _types: PhantomData,
             },
         })
@@ -415,9 +475,12 @@ impl<'py, P: PythonizeTypes> ser::SerializeTupleVariant for PythonTupleVariantSe
     }
 
     fn end(self) -> Result<Bound<'py, PyAny>> {
-        let d = PyDict::new_bound(self.inner.py);
-        d.set_item(self.variant, ser::SerializeTuple::end(self.inner)?)?;
-        Ok(d.into_any())
+        let m = P::Map::create_mapping_with_items_name(
+            self.inner.py,
+            self.name,
+            [(self.variant, ser::SerializeTuple::end(self.inner)?)],
+        )?;
+        Ok(m.into_any())
     }
 }
 
@@ -437,21 +500,22 @@ impl<'py, P: PythonizeTypes> ser::SerializeMap for PythonMapSerializer<'py, P> {
     where
         T: ?Sized + Serialize,
     {
-        self.map.set_item(
+        self.items.push((
             self.key
                 .take()
                 .expect("serialize_value should always be called after serialize_key"),
             pythonize_custom::<P, _>(self.py, value)?,
-        )?;
+        ));
         Ok(())
     }
 
     fn end(self) -> Result<Bound<'py, PyAny>> {
-        Ok(self.map.into_any())
+        let m = P::Map::create_mapping_with_items(self.py, self.items)?;
+        Ok(m.into_any())
     }
 }
 
-impl<'py, P: PythonizeTypes> ser::SerializeStruct for PythonDictSerializer<'py, P> {
+impl<'py, P: PythonizeTypes> ser::SerializeStruct for PythonStructDictSerializer<'py, P> {
     type Ok = Bound<'py, PyAny>;
     type Error = PythonizeError;
 
@@ -459,13 +523,14 @@ impl<'py, P: PythonizeTypes> ser::SerializeStruct for PythonDictSerializer<'py, 
     where
         T: ?Sized + Serialize,
     {
-        Ok(self
-            .dict
-            .set_item(key, pythonize_custom::<P, _>(self.py, value)?)?)
+        self.fields
+            .push((key, pythonize_custom::<P, _>(self.py, value)?));
+        Ok(())
     }
 
     fn end(self) -> Result<Bound<'py, PyAny>> {
-        Ok(self.dict.into_any())
+        let m = P::Map::create_mapping_with_items_name(self.py, self.name, self.fields)?;
+        Ok(m.into_any())
     }
 }
 
@@ -478,15 +543,20 @@ impl<'py, P: PythonizeTypes> ser::SerializeStructVariant for PythonStructVariant
         T: ?Sized + Serialize,
     {
         self.inner
-            .dict
-            .set_item(key, pythonize_custom::<P, _>(self.inner.py, value)?)?;
+            .fields
+            .push((key, pythonize_custom::<P, _>(self.inner.py, value)?));
         Ok(())
     }
 
     fn end(self) -> Result<Bound<'py, PyAny>> {
-        let d = PyDict::new_bound(self.inner.py);
-        d.set_item(self.variant, self.inner.dict)?;
-        Ok(d.into_any())
+        let v = P::Map::create_mapping_with_items_name(
+            self.inner.py,
+            self.inner.name,
+            self.inner.fields,
+        )?;
+        let m =
+            P::Map::create_mapping_with_items_name(self.inner.py, self.name, [(self.variant, v)])?;
+        Ok(m.into_any())
     }
 }
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -24,8 +24,11 @@ pub trait PythonizeNamedMappingType {
     type Builder<'py>: MappingBuilder<'py>;
 
     /// Create a builder for a Python mapping with a name
-    fn create_builder<'py>(py: Python<'py>, len: usize, name: &str)
-        -> PyResult<Self::Builder<'py>>;
+    fn create_builder<'py>(
+        py: Python<'py>,
+        len: usize,
+        name: &'static str,
+    ) -> PyResult<Self::Builder<'py>>;
 }
 
 /// Trait for types which can build a Python mapping
@@ -73,7 +76,7 @@ impl PythonizeNamedMappingType for PyDict {
     fn create_builder<'py>(
         py: Python<'py>,
         _len: usize,
-        _name: &str,
+        _name: &'static str,
     ) -> PyResult<Self::Builder<'py>> {
         Ok(Self::new_bound(py))
     }

--- a/tests/test_custom_types.rs
+++ b/tests/test_custom_types.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use pyo3::{
     exceptions::{PyIndexError, PyKeyError},
     prelude::*,
-    types::{PyDict, PyList, PyMapping, PySequence},
+    types::{PyDict, PyMapping, PySequence, PyTuple},
 };
 use pythonize::{
     depythonize, pythonize_custom, PythonizeListType, PythonizeMappingType, PythonizeTypes,
@@ -134,7 +134,7 @@ struct PythonizeCustomDict;
 impl PythonizeTypes for PythonizeCustomDict {
     type Map = CustomDict;
     type NamedMap = PythonizeUnnamedMappingWrapper<CustomDict>;
-    type List = PyList;
+    type List = PyTuple;
 }
 
 #[test]
@@ -148,6 +148,19 @@ fn test_custom_dict() {
 
         let deserialized: Value = depythonize(&serialized).unwrap();
         assert_eq!(deserialized, json!({ "hello": 1, "world": 2 }));
+    })
+}
+
+#[test]
+fn test_tuple() {
+    Python::with_gil(|py| {
+        PyMapping::register::<CustomDict>(py).unwrap();
+        let serialized =
+            pythonize_custom::<PythonizeCustomDict, _>(py, &json!([1, 2, 3, 4])).unwrap();
+        assert!(serialized.is_instance_of::<PyTuple>());
+
+        let deserialized: Value = depythonize(&serialized).unwrap();
+        assert_eq!(deserialized, json!([1, 2, 3, 4]));
     })
 }
 

--- a/tests/test_custom_types.rs
+++ b/tests/test_custom_types.rs
@@ -125,7 +125,7 @@ impl PythonizeNamedMappingType for CustomDict {
     fn create_builder<'py>(
         py: Python<'py>,
         len: usize,
-        _name: &str,
+        _name: &'static str,
     ) -> PyResult<Self::Builder<'py>> {
         Bound::new(
             py,

--- a/tests/test_custom_types.rs
+++ b/tests/test_custom_types.rs
@@ -6,8 +6,8 @@ use pyo3::{
     types::{PyDict, PyList, PyMapping, PySequence},
 };
 use pythonize::{
-    depythonize, pythonize_custom, MappingBuilder, PythonizeListType, PythonizeMappingType,
-    PythonizeNamedMappingType, PythonizeTypes, Pythonizer,
+    depythonize, pythonize_custom, PythonizeListType, PythonizeMappingType, PythonizeTypes,
+    PythonizeUnnamedMappingWrapper, Pythonizer,
 };
 use serde::Serialize;
 use serde_json::{json, Value};
@@ -58,7 +58,7 @@ impl PythonizeListType for CustomList {
 struct PythonizeCustomList;
 impl PythonizeTypes for PythonizeCustomList {
     type Map = PyDict;
-    type NamedMap = PyDict;
+    type NamedMap = PythonizeUnnamedMappingWrapper<PyDict>;
     type List = CustomList;
 }
 
@@ -106,53 +106,34 @@ impl CustomDict {
 }
 
 impl PythonizeMappingType for CustomDict {
-    type Builder<'py> = CustomDictBuilder<'py>;
+    type Builder<'py> = Bound<'py, CustomDict>;
 
-    fn create_builder<'py>(py: Python<'py>, len: Option<usize>) -> PyResult<Self::Builder<'py>> {
+    fn builder<'py>(py: Python<'py>, len: Option<usize>) -> PyResult<Self::Builder<'py>> {
         Bound::new(
             py,
             CustomDict {
                 items: HashMap::with_capacity(len.unwrap_or(0)),
             },
         )
-        .map(CustomDictBuilder)
-    }
-}
-
-impl PythonizeNamedMappingType for CustomDict {
-    type Builder<'py> = CustomDictBuilder<'py>;
-
-    fn create_builder<'py>(
-        py: Python<'py>,
-        len: usize,
-        _name: &'static str,
-    ) -> PyResult<Self::Builder<'py>> {
-        Bound::new(
-            py,
-            CustomDict {
-                items: HashMap::with_capacity(len),
-            },
-        )
-        .map(CustomDictBuilder)
-    }
-}
-
-struct CustomDictBuilder<'py>(Bound<'py, CustomDict>);
-
-impl<'py> MappingBuilder<'py> for CustomDictBuilder<'py> {
-    fn push_item<K: ToPyObject, V: ToPyObject>(&mut self, key: K, value: V) -> PyResult<()> {
-        unsafe { self.0.downcast_unchecked::<PyMapping>() }.set_item(key, value)
     }
 
-    fn finish(self) -> PyResult<Bound<'py, PyMapping>> {
-        Ok(unsafe { self.0.into_any().downcast_into_unchecked() })
+    fn push_item<'py, K: ToPyObject, V: ToPyObject>(
+        builder: &mut Self::Builder<'py>,
+        key: K,
+        value: V,
+    ) -> PyResult<()> {
+        unsafe { builder.downcast_unchecked::<PyMapping>() }.set_item(key, value)
+    }
+
+    fn finish<'py>(builder: Self::Builder<'py>) -> PyResult<Bound<'py, PyMapping>> {
+        Ok(unsafe { builder.into_any().downcast_into_unchecked() })
     }
 }
 
 struct PythonizeCustomDict;
 impl PythonizeTypes for PythonizeCustomDict {
     type Map = CustomDict;
-    type NamedMap = CustomDict;
+    type NamedMap = PythonizeUnnamedMappingWrapper<CustomDict>;
     type List = PyList;
 }
 

--- a/tests/test_custom_types.rs
+++ b/tests/test_custom_types.rs
@@ -56,9 +56,9 @@ impl PythonizeListType for CustomList {
 }
 
 struct PythonizeCustomList;
-impl PythonizeTypes for PythonizeCustomList {
+impl<'py> PythonizeTypes<'py> for PythonizeCustomList {
     type Map = PyDict;
-    type NamedMap = PythonizeUnnamedMappingWrapper<PyDict>;
+    type NamedMap = PythonizeUnnamedMappingWrapper<'py, PyDict>;
     type List = CustomList;
 }
 
@@ -105,10 +105,10 @@ impl CustomDict {
     }
 }
 
-impl PythonizeMappingType for CustomDict {
-    type Builder<'py> = Bound<'py, CustomDict>;
+impl<'py> PythonizeMappingType<'py> for CustomDict {
+    type Builder = Bound<'py, CustomDict>;
 
-    fn builder<'py>(py: Python<'py>, len: Option<usize>) -> PyResult<Self::Builder<'py>> {
+    fn builder(py: Python<'py>, len: Option<usize>) -> PyResult<Self::Builder> {
         Bound::new(
             py,
             CustomDict {
@@ -117,23 +117,23 @@ impl PythonizeMappingType for CustomDict {
         )
     }
 
-    fn push_item<'py, K: ToPyObject, V: ToPyObject>(
-        builder: &mut Self::Builder<'py>,
-        key: K,
-        value: V,
+    fn push_item(
+        builder: &mut Self::Builder,
+        key: Bound<'py, PyAny>,
+        value: Bound<'py, PyAny>,
     ) -> PyResult<()> {
         unsafe { builder.downcast_unchecked::<PyMapping>() }.set_item(key, value)
     }
 
-    fn finish<'py>(builder: Self::Builder<'py>) -> PyResult<Bound<'py, PyMapping>> {
+    fn finish(builder: Self::Builder) -> PyResult<Bound<'py, PyMapping>> {
         Ok(unsafe { builder.into_any().downcast_into_unchecked() })
     }
 }
 
 struct PythonizeCustomDict;
-impl PythonizeTypes for PythonizeCustomDict {
+impl<'py> PythonizeTypes<'py> for PythonizeCustomDict {
     type Map = CustomDict;
-    type NamedMap = PythonizeUnnamedMappingWrapper<CustomDict>;
+    type NamedMap = PythonizeUnnamedMappingWrapper<'py, CustomDict>;
     type List = PyTuple;
 }
 

--- a/tests/test_custom_types.rs
+++ b/tests/test_custom_types.rs
@@ -6,8 +6,8 @@ use pyo3::{
     types::{PyDict, PyMapping, PySequence, PyTuple},
 };
 use pythonize::{
-    depythonize, pythonize_custom, PythonizeListType, PythonizeMappingType, PythonizeTypes,
-    PythonizeUnnamedMappingAdapter, Pythonizer,
+    depythonize, pythonize_custom, PythonizeListType, PythonizeMappingType,
+    PythonizeNamedMappingType, PythonizeTypes, PythonizeUnnamedMappingAdapter, Pythonizer,
 };
 use serde::Serialize;
 use serde_json::{json, Value};
@@ -178,5 +178,104 @@ fn test_pythonizer_can_be_created() {
             .serialize(Pythonizer::custom::<PythonizeCustomDict>(py))
             .unwrap()
             .is_instance_of::<CustomDict>());
+    })
+}
+
+#[pyclass(mapping)]
+struct NamedCustomDict {
+    name: String,
+    items: HashMap<String, PyObject>,
+}
+
+#[pymethods]
+impl NamedCustomDict {
+    fn __len__(&self) -> usize {
+        self.items.len()
+    }
+
+    fn __getitem__(&self, key: String) -> PyResult<PyObject> {
+        self.items
+            .get(&key)
+            .cloned()
+            .ok_or_else(|| PyKeyError::new_err(key))
+    }
+
+    fn __setitem__(&mut self, key: String, value: PyObject) {
+        self.items.insert(key, value);
+    }
+
+    fn keys(&self) -> Vec<&String> {
+        self.items.keys().collect()
+    }
+
+    fn values(&self) -> Vec<PyObject> {
+        self.items.values().cloned().collect()
+    }
+}
+
+impl<'py> PythonizeNamedMappingType<'py> for NamedCustomDict {
+    type Builder = Bound<'py, NamedCustomDict>;
+
+    fn builder(py: Python<'py>, len: usize, name: &'static str) -> PyResult<Self::Builder> {
+        Bound::new(
+            py,
+            NamedCustomDict {
+                name: String::from(name),
+                items: HashMap::with_capacity(len),
+            },
+        )
+    }
+
+    fn push_field(
+        builder: &mut Self::Builder,
+        name: Bound<'py, pyo3::types::PyString>,
+        value: Bound<'py, PyAny>,
+    ) -> PyResult<()> {
+        unsafe { builder.downcast_unchecked::<PyMapping>() }.set_item(name, value)
+    }
+
+    fn finish(builder: Self::Builder) -> PyResult<Bound<'py, PyMapping>> {
+        Ok(unsafe { builder.into_any().downcast_into_unchecked() })
+    }
+}
+
+struct PythonizeNamedCustomDict;
+impl<'py> PythonizeTypes<'py> for PythonizeNamedCustomDict {
+    type Map = CustomDict;
+    type NamedMap = NamedCustomDict;
+    type List = PyTuple;
+}
+
+#[derive(Serialize)]
+struct Struct {
+    hello: u8,
+    world: i8,
+}
+
+#[test]
+fn test_custom_unnamed_dict() {
+    Python::with_gil(|py| {
+        PyMapping::register::<CustomDict>(py).unwrap();
+        let serialized =
+            pythonize_custom::<PythonizeCustomDict, _>(py, &Struct { hello: 1, world: 2 }).unwrap();
+        assert!(serialized.is_instance_of::<CustomDict>());
+
+        let deserialized: Value = depythonize(&serialized).unwrap();
+        assert_eq!(deserialized, json!({ "hello": 1, "world": 2 }));
+    })
+}
+
+#[test]
+fn test_custom_named_dict() {
+    Python::with_gil(|py| {
+        PyMapping::register::<NamedCustomDict>(py).unwrap();
+        let serialized =
+            pythonize_custom::<PythonizeNamedCustomDict, _>(py, &Struct { hello: 1, world: 2 })
+                .unwrap();
+        let named: Bound<NamedCustomDict> = serialized.extract().unwrap();
+        assert_eq!(named.borrow().name, "Struct");
+
+        let deserialized: Value = depythonize(&serialized).unwrap();
+        assert_eq!(deserialized, json!({ "hello": 1, "world": 2 }));
     })
 }

--- a/tests/test_custom_types.rs
+++ b/tests/test_custom_types.rs
@@ -7,7 +7,7 @@ use pyo3::{
 };
 use pythonize::{
     depythonize, pythonize_custom, PythonizeListType, PythonizeMappingType, PythonizeTypes,
-    PythonizeUnnamedMappingWrapper, Pythonizer,
+    PythonizeUnnamedMappingAdapter, Pythonizer,
 };
 use serde::Serialize;
 use serde_json::{json, Value};
@@ -58,7 +58,7 @@ impl PythonizeListType for CustomList {
 struct PythonizeCustomList;
 impl<'py> PythonizeTypes<'py> for PythonizeCustomList {
     type Map = PyDict;
-    type NamedMap = PythonizeUnnamedMappingWrapper<'py, PyDict>;
+    type NamedMap = PythonizeUnnamedMappingAdapter<'py, PyDict>;
     type List = CustomList;
 }
 
@@ -133,7 +133,7 @@ impl<'py> PythonizeMappingType<'py> for CustomDict {
 struct PythonizeCustomDict;
 impl<'py> PythonizeTypes<'py> for PythonizeCustomDict {
     type Map = CustomDict;
-    type NamedMap = PythonizeUnnamedMappingWrapper<'py, CustomDict>;
+    type NamedMap = PythonizeUnnamedMappingAdapter<'py, CustomDict>;
     type List = PyTuple;
 }
 

--- a/tests/test_with_serde_path_to_err.rs
+++ b/tests/test_with_serde_path_to_err.rs
@@ -15,6 +15,7 @@ struct Root<T> {
 
 impl<T> PythonizeTypes for Root<T> {
     type Map = PyDict;
+    type NamedMap = PyDict;
     type List = PyList;
 }
 

--- a/tests/test_with_serde_path_to_err.rs
+++ b/tests/test_with_serde_path_to_err.rs
@@ -4,7 +4,7 @@ use pyo3::{
     prelude::*,
     types::{PyDict, PyList},
 };
-use pythonize::PythonizeTypes;
+use pythonize::{PythonizeTypes, PythonizeUnnamedMappingWrapper};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -15,7 +15,7 @@ struct Root<T> {
 
 impl<T> PythonizeTypes for Root<T> {
     type Map = PyDict;
-    type NamedMap = PyDict;
+    type NamedMap = PythonizeUnnamedMappingWrapper<PyDict>;
     type List = PyList;
 }
 

--- a/tests/test_with_serde_path_to_err.rs
+++ b/tests/test_with_serde_path_to_err.rs
@@ -4,7 +4,7 @@ use pyo3::{
     prelude::*,
     types::{PyDict, PyList},
 };
-use pythonize::{PythonizeTypes, PythonizeUnnamedMappingWrapper};
+use pythonize::{PythonizeTypes, PythonizeUnnamedMappingAdapter};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -15,7 +15,7 @@ struct Root<T> {
 
 impl<'py, T> PythonizeTypes<'py> for Root<T> {
     type Map = PyDict;
-    type NamedMap = PythonizeUnnamedMappingWrapper<'py, PyDict>;
+    type NamedMap = PythonizeUnnamedMappingAdapter<'py, PyDict>;
     type List = PyList;
 }
 

--- a/tests/test_with_serde_path_to_err.rs
+++ b/tests/test_with_serde_path_to_err.rs
@@ -13,9 +13,9 @@ struct Root<T> {
     root_map: BTreeMap<String, Nested<T>>,
 }
 
-impl<T> PythonizeTypes for Root<T> {
+impl<'py, T> PythonizeTypes<'py> for Root<T> {
     type Map = PyDict;
-    type NamedMap = PythonizeUnnamedMappingWrapper<PyDict>;
+    type NamedMap = PythonizeUnnamedMappingWrapper<'py, PyDict>;
     type List = PyList;
 }
 


### PR DESCRIPTION
This PR includes four changes:

- Implement `PythonizeListType` for `PyTuple`, a small convenience that cannot be achieved outside the crate
- Add support for prebuilding mappings during serialisation, which delays the collection of mapping key-value pairs until all are known
- Add support for named mappings during serialisation, which adds a tiny default-implemented helper trait method to pass forward the struct / tuple / enum name to the mapping type
- Allow deserializing an enum from any mapping instead of just dicts

I have found them to be very useful to serialise to and from class-like Python types (e.g. `namedtuple` which keep more type information around).