### PR TITLE
Update to PyO3 0.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Packaging
+- Update to PyO3 0.23
+
 ## 0.22.0 - 2024-08-10
 
 ### Packaging

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ documentation = "https://docs.rs/crate/pythonize/"
 
 [dependencies]
 serde = { version = "1.0", default-features = false, features = ["std"] }
-pyo3 = { version = "0.22.2", default-features = false }
+pyo3 = { version = "0.23.1", default-features = false }
 
 [dev-dependencies]
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-pyo3 = { version = "0.22.2", default-features = false, features = ["auto-initialize", "macros", "py-clone"] }
+pyo3 = { version = "0.23.1", default-features = false, features = ["auto-initialize", "macros", "py-clone"] }
 serde_json = "1.0"
 serde_bytes = "0.11"
 maplit = "1.0.2"

--- a/src/de.rs
+++ b/src/de.rs
@@ -529,8 +529,8 @@ mod test {
     use super::*;
     use crate::error::ErrorImpl;
     use maplit::hashmap;
-    use pyo3::{IntoPyObject, Python};
     use pyo3::ffi::c_str;
+    use pyo3::{IntoPyObject, Python};
     use serde_json::{json, Value as JsonValue};
 
     fn test_de<T>(code: &CStr, expected: &T, expected_json: &JsonValue)
@@ -830,7 +830,8 @@ mod test {
         };
         let expected_json =
             json!({"name": "SomeFoo", "bar": { "value": 13, "variant": { "Tuple": [-1.5, 8]}}});
-        let code = c_str!("{'name': 'SomeFoo', 'bar': {'value': 13, 'variant': {'Tuple': [-1.5, 8]}}}");
+        let code =
+            c_str!("{'name': 'SomeFoo', 'bar': {'value': 13, 'variant': {'Tuple': [-1.5, 8]}}}");
         test_de(code, &expected, &expected_json);
     }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -530,6 +530,7 @@ mod test {
     use crate::error::ErrorImpl;
     use maplit::hashmap;
     use pyo3::{IntoPyObject, Python};
+    use pyo3::ffi::c_str;
     use serde_json::{json, Value as JsonValue};
 
     fn test_de<T>(code: &CStr, expected: &T, expected_json: &JsonValue)
@@ -556,7 +557,7 @@ mod test {
 
         let expected = Empty;
         let expected_json = json!(null);
-        let code = c"None";
+        let code = c_str!("None");
         test_de(code, &expected, &expected_json);
     }
 
@@ -582,7 +583,7 @@ mod test {
             "baz": 45.23,
             "qux": true
         });
-        let code = c"{'foo': 'Foo', 'bar': 8, 'baz': 45.23, 'qux': True}";
+        let code = c_str!("{'foo': 'Foo', 'bar': 8, 'baz': 45.23, 'qux': True}");
         test_de(code, &expected, &expected_json);
     }
 
@@ -594,7 +595,7 @@ mod test {
             bar: usize,
         }
 
-        let code = c"{'foo': 'Foo'}";
+        let code = c_str!("{'foo': 'Foo'}");
 
         Python::with_gil(|py| {
             let locals = PyDict::new(py);
@@ -613,7 +614,7 @@ mod test {
 
         let expected = TupleStruct("cat".to_string(), -10.05);
         let expected_json = json!(["cat", -10.05]);
-        let code = c"('cat', -10.05)";
+        let code = c_str!("('cat', -10.05)");
         test_de(code, &expected, &expected_json);
     }
 
@@ -622,7 +623,7 @@ mod test {
         #[derive(Debug, Deserialize, PartialEq)]
         struct TupleStruct(String, f64);
 
-        let code = c"('cat', -10.05, 'foo')";
+        let code = c_str!("('cat', -10.05, 'foo')");
 
         Python::with_gil(|py| {
             let locals = PyDict::new(py);
@@ -641,7 +642,7 @@ mod test {
 
         let expected = TupleStruct("cat".to_string(), -10.05);
         let expected_json = json!(["cat", -10.05]);
-        let code = c"['cat', -10.05]";
+        let code = c_str!("['cat', -10.05]");
         test_de(code, &expected, &expected_json);
     }
 
@@ -649,7 +650,7 @@ mod test {
     fn test_tuple() {
         let expected = ("foo".to_string(), 5);
         let expected_json = json!(["foo", 5]);
-        let code = c"('foo', 5)";
+        let code = c_str!("('foo', 5)");
         test_de(code, &expected, &expected_json);
     }
 
@@ -657,7 +658,7 @@ mod test {
     fn test_tuple_from_pylist() {
         let expected = ("foo".to_string(), 5);
         let expected_json = json!(["foo", 5]);
-        let code = c"['foo', 5]";
+        let code = c_str!("['foo', 5]");
         test_de(code, &expected, &expected_json);
     }
 
@@ -665,7 +666,7 @@ mod test {
     fn test_vec_from_pyset() {
         let expected = vec!["foo".to_string()];
         let expected_json = json!(["foo"]);
-        let code = c"{'foo'}";
+        let code = c_str!("{'foo'}");
         test_de(code, &expected, &expected_json);
     }
 
@@ -673,7 +674,7 @@ mod test {
     fn test_vec_from_pyfrozenset() {
         let expected = vec!["foo".to_string()];
         let expected_json = json!(["foo"]);
-        let code = c"frozenset({'foo'})";
+        let code = c_str!("frozenset({'foo'})");
         test_de(code, &expected, &expected_json);
     }
 
@@ -681,7 +682,7 @@ mod test {
     fn test_vec() {
         let expected = vec![3, 2, 1];
         let expected_json = json!([3, 2, 1]);
-        let code = c"[3, 2, 1]";
+        let code = c_str!("[3, 2, 1]");
         test_de(code, &expected, &expected_json);
     }
 
@@ -689,7 +690,7 @@ mod test {
     fn test_vec_from_tuple() {
         let expected = vec![3, 2, 1];
         let expected_json = json!([3, 2, 1]);
-        let code = c"(3, 2, 1)";
+        let code = c_str!("(3, 2, 1)");
         test_de(code, &expected, &expected_json);
     }
 
@@ -697,7 +698,7 @@ mod test {
     fn test_hashmap() {
         let expected = hashmap! {"foo".to_string() => 4};
         let expected_json = json!({"foo": 4 });
-        let code = c"{'foo': 4}";
+        let code = c_str!("{'foo': 4}");
         test_de(code, &expected, &expected_json);
     }
 
@@ -710,7 +711,7 @@ mod test {
 
         let expected = Foo::Variant;
         let expected_json = json!("Variant");
-        let code = c"'Variant'";
+        let code = c_str!("'Variant'");
         test_de(code, &expected, &expected_json);
     }
 
@@ -723,7 +724,7 @@ mod test {
 
         let expected = Foo::Tuple(12, "cat".to_string());
         let expected_json = json!({"Tuple": [12, "cat"]});
-        let code = c"{'Tuple': [12, 'cat']}";
+        let code = c_str!("{'Tuple': [12, 'cat']}");
         test_de(code, &expected, &expected_json);
     }
 
@@ -736,7 +737,7 @@ mod test {
 
         let expected = Foo::NewType("cat".to_string());
         let expected_json = json!({"NewType": "cat" });
-        let code = c"{'NewType': 'cat'}";
+        let code = c_str!("{'NewType': 'cat'}");
         test_de(code, &expected, &expected_json);
     }
 
@@ -752,7 +753,7 @@ mod test {
             bar: 25,
         };
         let expected_json = json!({"Struct": {"foo": "cat", "bar": 25 }});
-        let code = c"{'Struct': {'foo': 'cat', 'bar': 25}}";
+        let code = c_str!("{'Struct': {'foo': 'cat', 'bar': 25}}");
         test_de(code, &expected, &expected_json);
     }
     #[test]
@@ -765,7 +766,7 @@ mod test {
 
         let expected = Foo::Tuple(12.0, 'c');
         let expected_json = json!([12.0, 'c']);
-        let code = c"[12.0, 'c']";
+        let code = c_str!("[12.0, 'c']");
         test_de(code, &expected, &expected_json);
     }
 
@@ -779,7 +780,7 @@ mod test {
 
         let expected = Foo::NewType("cat".to_string());
         let expected_json = json!("cat");
-        let code = c"'cat'";
+        let code = c_str!("'cat'");
         test_de(code, &expected, &expected_json);
     }
 
@@ -796,7 +797,7 @@ mod test {
             bar: [2, 5, 3, 1],
         };
         let expected_json = json!({"foo": ["a", "b", "c"], "bar": [2, 5, 3, 1]});
-        let code = c"{'foo': ['a', 'b', 'c'], 'bar': [2, 5, 3, 1]}";
+        let code = c_str!("{'foo': ['a', 'b', 'c'], 'bar': [2, 5, 3, 1]}");
         test_de(code, &expected, &expected_json);
     }
 
@@ -829,7 +830,7 @@ mod test {
         };
         let expected_json =
             json!({"name": "SomeFoo", "bar": { "value": 13, "variant": { "Tuple": [-1.5, 8]}}});
-        let code = c"{'name': 'SomeFoo', 'bar': {'value': 13, 'variant': {'Tuple': [-1.5, 8]}}}";
+        let code = c_str!("{'name': 'SomeFoo', 'bar': {'value': 13, 'variant': {'Tuple': [-1.5, 8]}}}");
         test_de(code, &expected, &expected_json);
     }
 
@@ -878,7 +879,7 @@ mod test {
     fn test_char() {
         let expected = 'a';
         let expected_json = json!("a");
-        let code = c"'a'";
+        let code = c_str!("'a'");
         test_de(code, &expected, &expected_json);
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 use pyo3::PyErr;
 use pyo3::{exceptions::*, DowncastError, DowncastIntoError};
 use serde::{de, ser};
+use std::convert::Infallible;
 use std::error;
 use std::fmt::{self, Debug, Display};
 use std::result;
@@ -133,6 +134,13 @@ impl de::Error for PythonizeError {
         Self {
             inner: Box::new(ErrorImpl::Message(msg.to_string())),
         }
+    }
+}
+
+/// Convert an exception raised in Python to a `PythonizeError`
+impl From<Infallible> for PythonizeError {
+    fn from(other: Infallible) -> Self {
+        match other {}
     }
 }
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -624,6 +624,7 @@ impl<'py, P: PythonizeTypes<'py>> ser::SerializeStructVariant
 mod test {
     use super::pythonize;
     use maplit::hashmap;
+    use pyo3::ffi::c_str;
     use pyo3::prelude::*;
     use pyo3::pybacked::PyBackedStr;
     use pyo3::types::{PyBytes, PyDict};
@@ -640,7 +641,7 @@ mod test {
             locals.set_item("obj", obj)?;
 
             py.run(
-                c"import json; result = json.dumps(obj, separators=(',', ':'))",
+                c_str!("import json; result = json.dumps(obj, separators=(',', ':'))"),
                 None,
                 Some(&locals),
             )?;

--- a/tests/test_with_serde_path_to_err.rs
+++ b/tests/test_with_serde_path_to_err.rs
@@ -41,14 +41,14 @@ impl Serialize for CannotSerialize {
 #[test]
 fn test_de_valid() {
     Python::with_gil(|py| {
-        let pyroot = PyDict::new_bound(py);
+        let pyroot = PyDict::new(py);
         pyroot.set_item("root_key", "root_value").unwrap();
 
-        let nested = PyDict::new_bound(py);
-        let nested_0 = PyDict::new_bound(py);
+        let nested = PyDict::new(py);
+        let nested_0 = PyDict::new(py);
         nested_0.set_item("nested_key", "nested_value_0").unwrap();
         nested.set_item("nested_0", nested_0).unwrap();
-        let nested_1 = PyDict::new_bound(py);
+        let nested_1 = PyDict::new(py);
         nested_1.set_item("nested_key", "nested_value_1").unwrap();
         nested.set_item("nested_1", nested_1).unwrap();
 
@@ -83,14 +83,14 @@ fn test_de_valid() {
 #[test]
 fn test_de_invalid() {
     Python::with_gil(|py| {
-        let pyroot = PyDict::new_bound(py);
+        let pyroot = PyDict::new(py);
         pyroot.set_item("root_key", "root_value").unwrap();
 
-        let nested = PyDict::new_bound(py);
-        let nested_0 = PyDict::new_bound(py);
+        let nested = PyDict::new(py);
+        let nested_0 = PyDict::new(py);
         nested_0.set_item("nested_key", "nested_value_0").unwrap();
         nested.set_item("nested_0", nested_0).unwrap();
-        let nested_1 = PyDict::new_bound(py);
+        let nested_1 = PyDict::new(py);
         nested_1.set_item("nested_key", 1).unwrap();
         nested.set_item("nested_1", nested_1).unwrap();
 


### PR DESCRIPTION
This updates Pythonize to work with PyO3 0.23.x. Apologies if you've started work on this already — feel free to close if so :).

 - `xyz_bound` methods have been renamed to `xyz`.
 - Use `IntoPyObject` for conversion to Python. Several of the conversion methods now return a `Borrowed` rather than `Bound` value, and so some of the serialisation functions need to convert to 
a `Bound<_>` first — I've moved that into a helper function, but happy to inline that if preferred.
 - `eval`/`run` now take a `&CStr` rather than `&str`, so we use C string literals in the tests.