### PR TITLE
remove `depythonize_bound`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Packaging
 - Update to PyO3 0.24
 
+## Removed
+- Remove deprecated `depythonize_bound()`
+
 ## 0.23.0 - 2024-11-22
 
 ### Packaging

--- a/src/de.rs
+++ b/src/de.rs
@@ -12,15 +12,6 @@ where
     T::deserialize(&mut Depythonizer::from_object(obj))
 }
 
-/// Attempt to convert a Python object to an instance of `T`
-#[deprecated(since = "0.22.0", note = "use `depythonize` instead")]
-pub fn depythonize_bound<T>(obj: Bound<PyAny>) -> Result<T>
-where
-    T: DeserializeOwned,
-{
-    T::deserialize(&mut Depythonizer::from_object(&obj))
-}
-
 /// A structure that deserializes Python objects into Rust values
 pub struct Depythonizer<'a, 'py> {
     input: &'a Bound<'py, PyAny>,

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,5 +1,5 @@
 use pyo3::{types::*, Bound};
-use serde::de::{self, DeserializeOwned, IntoDeserializer};
+use serde::de::{self, IntoDeserializer};
 use serde::Deserialize;
 
 use crate::error::{ErrorImpl, PythonizeError, Result};
@@ -532,12 +532,9 @@ mod test {
             let obj = py.eval(code, None, None).unwrap();
             let actual: T = depythonize(&obj).unwrap();
             assert_eq!(&actual, expected);
+
             let actual_json: JsonValue = depythonize(&obj).unwrap();
             assert_eq!(&actual_json, expected_json);
-
-            #[allow(deprecated)]
-            let actual: T = depythonize_bound(obj.clone()).unwrap();
-            assert_eq!(&actual, expected);
         });
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,6 @@ mod de;
 mod error;
 mod ser;
 
-#[allow(deprecated)]
-pub use crate::de::depythonize_bound;
 pub use crate::de::{depythonize, Depythonizer};
 pub use crate::error::{PythonizeError, Result};
 pub use crate::ser::{

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -55,7 +55,7 @@ pub trait PythonizeListType: Sized {
     fn create_sequence<'py, T, U>(
         py: Python<'py>,
         elements: impl IntoIterator<Item = T, IntoIter = U>,
-    ) -> PyResult<Bound<PySequence>>
+    ) -> PyResult<Bound<'py, PySequence>>
     where
         T: IntoPyObject<'py>,
         U: ExactSizeIterator<Item = T>;
@@ -130,7 +130,7 @@ impl PythonizeListType for PyList {
     fn create_sequence<'py, T, U>(
         py: Python<'py>,
         elements: impl IntoIterator<Item = T, IntoIter = U>,
-    ) -> PyResult<Bound<PySequence>>
+    ) -> PyResult<Bound<'py, PySequence>>
     where
         T: IntoPyObject<'py>,
         U: ExactSizeIterator<Item = T>,
@@ -143,7 +143,7 @@ impl PythonizeListType for PyTuple {
     fn create_sequence<'py, T, U>(
         py: Python<'py>,
         elements: impl IntoIterator<Item = T, IntoIter = U>,
-    ) -> PyResult<Bound<PySequence>>
+    ) -> PyResult<Bound<'py, PySequence>>
     where
         T: IntoPyObject<'py>,
         U: ExactSizeIterator<Item = T>,

--- a/tests/test_custom_types.rs
+++ b/tests/test_custom_types.rs
@@ -36,7 +36,7 @@ impl PythonizeListType for CustomList {
     fn create_sequence<'py, T, U>(
         py: Python<'py>,
         elements: impl IntoIterator<Item = T, IntoIter = U>,
-    ) -> PyResult<Bound<PySequence>>
+    ) -> PyResult<Bound<'py, PySequence>>
     where
         T: IntoPyObject<'py>,
         U: ExactSizeIterator<Item = T>,


### PR DESCRIPTION
Was deprecated in 0.22, so let's remove for the upcoming 0.24 release.