### PR TITLE
Update PyO3 version to 0.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Packaging
+- Update to PyO3 0.24.1
+
 ## 0.24.0 - 2025-03-26
 
 ### Packaging

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pythonize"
-version = "0.24.0"
+version = "0.25.0"
 authors = ["David Hewitt <1939362+davidhewitt@users.noreply.github.com>"]
 edition = "2021"
 rust-version = "1.63"
@@ -13,11 +13,11 @@ documentation = "https://docs.rs/crate/pythonize/"
 
 [dependencies]
 serde = { version = "1.0", default-features = false, features = ["std"] }
-pyo3 = { version = "0.24", default-features = false }
+pyo3 = { version = "0.24.1", default-features = false }
 
 [dev-dependencies]
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-pyo3 = { version = "0.24", default-features = false, features = ["auto-initialize", "macros", "py-clone"] }
+pyo3 = { version = "0.24.1", default-features = false, features = ["auto-initialize", "macros", "py-clone"] }
 serde_json = "1.0"
 serde_bytes = "0.11"
 maplit = "1.0.2"


### PR DESCRIPTION
Simple update to PyO3 version 0.24.1 for [security fix](https://github.com/PyO3/pyo3/releases/tag/v0.24.1).