### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ pyo3 = { version = "0.24", default-features = false }
 
 [dev-dependencies]
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-pyo3 = { version = "0.24", default-features = false, features = ["auto-initialize", "macros", "py-clone"] }
+pyo3 = { version = "0.24.1", default-features = false, features = ["auto-initialize", "macros", "py-clone"] }
 serde_json = "1.0"
 serde_bytes = "0.11"
 maplit = "1.0.2"


### PR DESCRIPTION
Bumps the dependency to at least 0.24.1 as per the advisory

[Advisory](https://rustsec.org/advisories/RUSTSEC-2025-0020.html)

(even though this crate may not be using the function mentioned in the advisory, it is better to bump it to ensure that there is no chance of other dependencies pulling it)