### PR TITLE
release: 0.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 0.26.0 - 2025-08-30
+
+### Packaging
+- Bump MSRV to 1.74
+- Update to PyO3 0.26
+
+### Changed
+- `PythonizeTypes`, `PythonizeMappingType` and `PythonizeNamedMappingType` no longer have a lifetime on the trait, instead the `Builder` type is a GAT.
+
+## 0.25.0 - 2025-05-23
+
+### Packaging
+- Update to PyO3 0.25
+
 ## 0.24.0 - 2025-03-26
 
 ### Packaging

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "pythonize"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["David Hewitt <1939362+davidhewitt@users.noreply.github.com>"]
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.74"
 license = "MIT"
 description = "Serde Serializer & Deserializer from Rust <--> Python, backed by PyO3."
 homepage = "https://github.com/davidhewitt/pythonize"
@@ -13,11 +13,11 @@ documentation = "https://docs.rs/crate/pythonize/"
 
 [dependencies]
 serde = { version = "1.0", default-features = false, features = ["std"] }
-pyo3 = { version = "0.25", default-features = false }
+pyo3 = { version = "0.26", default-features = false }
 
 [dev-dependencies]
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-pyo3 = { version = "0.25", default-features = false, features = ["auto-initialize", "macros", "py-clone"] }
+pyo3 = { version = "0.26", default-features = false, features = ["auto-initialize", "macros", "py-clone"] }
 serde_json = "1.0"
 serde_bytes = "0.11"
 maplit = "1.0.2"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ let sample = Sample {
     bar: None
 };
 
-Python::with_gil(|py| {
+Python::attach(|py| {
     // Rust -> Python
     let obj =  pythonize(py, &sample).unwrap();
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -73,7 +73,7 @@ pub enum ErrorImpl {
     Message(String),
     /// A Python type not supported by the deserializer
     UnsupportedType(String),
-    /// A `PyAny` object that failed to downcast to an expected Python type
+    /// A `PyAny` object that failed to cast to an expected Python type
     UnexpectedType(String),
     /// Dict keys should be strings to deserialize to struct fields
     DictKeyNotString,

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -632,7 +632,7 @@ mod test {
     where
         T: Serialize,
     {
-        Python::with_gil(|py| -> PyResult<()> {
+        Python::attach(|py| -> PyResult<()> {
             let obj = pythonize(py, &src)?;
 
             let locals = PyDict::new(py);
@@ -845,7 +845,7 @@ mod test {
         // serde treats &[u8] as a sequence of integers due to lack of specialization
         test_ser(b"foo", "[102,111,111]");
 
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             assert!(pythonize(py, serde_bytes::Bytes::new(b"foo"))
                 .expect("bytes will always serialize successfully")
                 .eq(&PyBytes::new(py, b"foo"))

--- a/tests/test_with_serde_path_to_err.rs
+++ b/tests/test_with_serde_path_to_err.rs
@@ -40,7 +40,7 @@ impl Serialize for CannotSerialize {
 
 #[test]
 fn test_de_valid() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let pyroot = PyDict::new(py);
         pyroot.set_item("root_key", "root_value").unwrap();
 
@@ -82,7 +82,7 @@ fn test_de_valid() {
 
 #[test]
 fn test_de_invalid() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let pyroot = PyDict::new(py);
         pyroot.set_item("root_key", "root_value").unwrap();
 
@@ -106,7 +106,7 @@ fn test_de_invalid() {
 
 #[test]
 fn test_ser_valid() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let root = Root {
             root_key: String::from("root_value"),
             root_map: BTreeMap::from([
@@ -128,7 +128,7 @@ fn test_ser_valid() {
         let ser = pythonize::Pythonizer::<Root<String>>::from(py);
         let pyroot: Bound<'_, PyAny> = serde_path_to_error::serialize(&root, ser).unwrap();
 
-        let pyroot = pyroot.downcast::<PyDict>().unwrap();
+        let pyroot = pyroot.cast::<PyDict>().unwrap();
         assert_eq!(pyroot.len(), 2);
 
         let root_value: String = pyroot
@@ -181,7 +181,7 @@ fn test_ser_valid() {
 
 #[test]
 fn test_ser_invalid() {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let root = Root {
             root_key: String::from("root_value"),
             root_map: BTreeMap::from([


### PR DESCRIPTION
Bumps PyO3 to 0.26, fixes the deprecation warnings, and ready to ship.