### PR TITLE
fix: check codepoint count not byte length in deserialize_char

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -187,7 +187,7 @@ impl<'de> de::Deserializer<'de> for &'_ mut Depythonizer<'_, '_> {
         V: de::Visitor<'de>,
     {
         let s = self.input.cast::<PyString>()?.to_cow()?;
-        if s.len() != 1 {
+        if s.chars().count() != 1 {
             return Err(PythonizeError::invalid_length_char());
         }
         visitor.visit_char(s.chars().next().unwrap())
@@ -1015,6 +1015,19 @@ mod test {
         let expected_json = json!("a");
         let code = c"'a'";
         test_de(code, &expected, &expected_json);
+    }
+
+    #[test]
+    fn test_char_multibyte_codepoint() {
+        // 'ä' is U+00E4: one Unicode codepoint, two UTF-8 bytes.
+        // Previously, deserialize_char checked s.len() (byte length) != 1,
+        // which incorrectly rejected any non-ASCII char. The fix checks
+        // s.chars().count() (codepoint count) != 1 instead.
+        Python::attach(|py| {
+            let py_str = pyo3::types::PyString::new(py, "ä");
+            let result = depythonize::<char>(py_str.as_any());
+            assert_eq!(result.unwrap(), 'ä');
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Problem

deserialize_char guards against non-char-length strings with:

`ust
if s.len() != 1 {
    return Err(PythonizeError::invalid_length_char());
}
`

s.len() returns the **byte length** of the UTF-8 string. Any non-ASCII single-codepoint character (e.g. 'ä' U+00E4) is 1 codepoint but 2 UTF-8 bytes, so the guard fires incorrectly and depythonize::\<char\> returns Err(InvalidLengthChar) for valid input.

This affects every Unicode codepoint above U+007F — Latin Extended, Greek, Cyrillic, Arabic, CJK, emoji, etc.

## Fix

`ust
if s.chars().count() != 1 {
`

chars().count() counts Unicode codepoints, which is the semantically correct check for the char type.

## Test

A new test 	est_char_multibyte_codepoint is added in de.rs covering 'ä' (U+00E4, 2 UTF-8 bytes). The existing 	est_char (ASCII 'a') continues to pass.