### PR TITLE
test: add error-path and asymmetry characterisation tests

### DIFF
--- a/tests/test_asymmetry.rs
+++ b/tests/test_asymmetry.rs
@@ -1,0 +1,223 @@
+use std::collections::BTreeMap;
+
+use pyo3::prelude::*;
+use pyo3::types::PyString;
+use pythonize::{depythonize, pythonize};
+
+// ---------------------------------------------------------------------------
+// AC-1: Dict ordering — BTreeMap<String, i32> round-trip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_btreemap_round_trip_content_equality() {
+    Python::attach(|py| {
+        let mut map = BTreeMap::new();
+        map.insert("alpha".to_string(), 1i32);
+        map.insert("beta".to_string(), 2i32);
+        map.insert("gamma".to_string(), 3i32);
+
+        let py_val = pythonize(py, &map).expect("pythonize failed");
+        let result: Result<BTreeMap<String, i32>, _> = depythonize(&py_val);
+        assert!(result.is_ok());
+        let back = result.unwrap();
+        // BASELINE: content equal — BTreeMap serializes keys in sorted order
+        // (alpha, beta, gamma); Python dict (3.7+) preserves insertion order;
+        // round-trip into BTreeMap re-sorts on insert.  Content matches.
+        assert_eq!(back, map);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// AC-2: f32 precision — round-trip characterisation (is_ok only)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_f32_min_positive_round_trip_is_ok() {
+    Python::attach(|py| {
+        let val = f32::MIN_POSITIVE;
+        let py_val = pythonize(py, &val).expect("pythonize failed");
+        let result: Result<f32, _> = depythonize(&py_val);
+        // BASELINE: Ok(1.1754944e-38) — f32 → f64 (exact promotion) → Python
+        // float → f64 → f32; normal value round-trips without error.
+        assert!(result.is_ok());
+    });
+}
+
+#[test]
+fn test_f32_pi_round_trip_is_ok() {
+    Python::attach(|py| {
+        let val = std::f32::consts::PI;
+        let py_val = pythonize(py, &val).expect("pythonize failed");
+        let result: Result<f32, _> = depythonize(&py_val);
+        // BASELINE: Ok(3.1415927) — PI in f32 precision; f32→f64 promotion is
+        // lossless so back-conversion yields the original f32 bit pattern.
+        assert!(result.is_ok());
+    });
+}
+
+#[test]
+fn test_f32_subnormal_round_trip_is_ok() {
+    Python::attach(|py| {
+        // Smallest positive subnormal f32 (~1.4e-45)
+        let val = f32::from_bits(1u32);
+        let py_val = pythonize(py, &val).expect("pythonize failed");
+        let result: Result<f32, _> = depythonize(&py_val);
+        // BASELINE: Ok(1e-45) — subnormal f32 is representable in f64;
+        // round-trip completes without error.
+        assert!(result.is_ok());
+    });
+}
+
+// ---------------------------------------------------------------------------
+// AC-3: char length guard — Python str with >1 char → depythonize::<char>
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_depythonize_two_char_ascii_as_char_is_err() {
+    Python::attach(|py| {
+        let py_str = PyString::new(py, "ab");
+        let result: Result<char, _> = depythonize(py_str.as_any());
+        // assert!(err.to_string().contains("expected a str of length 1 for char"))
+        assert!(result.is_err());
+    });
+}
+
+#[test]
+fn test_depythonize_multi_char_unicode_as_char_is_err() {
+    Python::attach(|py| {
+        let py_str = PyString::new(py, "hello");
+        let result: Result<char, _> = depythonize(py_str.as_any());
+        // assert!(err.to_string().contains("expected a str of length 1 for char"))
+        assert!(result.is_err());
+    });
+}
+
+// ---------------------------------------------------------------------------
+// AC-4: bool as int — Python bool → depythonize::<i64>  (normative)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_depythonize_py_true_as_i64_is_one() {
+    Python::attach(|py| {
+        let py_true = pythonize(py, &true).unwrap();
+        let result: Result<i64, _> = depythonize(&py_true);
+        // BASELINE: Ok(1) — Python True is a subclass of int; the
+        // deserializer reads it as integer 1.
+        assert_eq!(result.unwrap(), 1i64);
+    });
+}
+
+#[test]
+fn test_depythonize_py_false_as_i64_is_zero() {
+    Python::attach(|py| {
+        let py_false = pythonize(py, &false).unwrap();
+        let result: Result<i64, _> = depythonize(&py_false);
+        // BASELINE: Ok(0) — Python False is a subclass of int; the
+        // deserializer reads it as integer 0.
+        assert_eq!(result.unwrap(), 0i64);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Additional: Rust bool → Python → back as bool (round-trip)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_bool_round_trip_true() {
+    Python::attach(|py| {
+        let py_val = pythonize(py, &true).unwrap();
+        let result: Result<bool, _> = depythonize(&py_val);
+        // BASELINE: Ok(true) — bool round-trip works correctly.
+        assert_eq!(result.unwrap(), true);
+    });
+}
+
+#[test]
+fn test_bool_round_trip_false() {
+    Python::attach(|py| {
+        let py_val = pythonize(py, &false).unwrap();
+        let result: Result<bool, _> = depythonize(&py_val);
+        // BASELINE: Ok(false) — bool round-trip works correctly.
+        assert_eq!(result.unwrap(), false);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Additional: Rust bool → Python → depythonize::<i32>
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_depythonize_py_true_as_i32() {
+    Python::attach(|py| {
+        let py_true = pythonize(py, &true).unwrap();
+        let result: Result<i32, _> = depythonize(&py_true);
+        // BASELINE: Ok(1) — Python True subclasses int; coerces to i32.
+        assert_eq!(result.unwrap(), 1i32);
+    });
+}
+
+#[test]
+fn test_depythonize_py_false_as_i32() {
+    Python::attach(|py| {
+        let py_false = pythonize(py, &false).unwrap();
+        let result: Result<i32, _> = depythonize(&py_false);
+        // BASELINE: Ok(0) — Python False subclasses int; coerces to i32.
+        assert_eq!(result.unwrap(), 0i32);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Additional: Python int 300 → depythonize::<i8> / ::<u8> (overflow probe)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_depythonize_int_300_as_i8_overflow() {
+    Python::attach(|py| {
+        let py_int = pythonize(py, &300i32).unwrap();
+        let result: Result<i8, _> = depythonize(&py_int);
+        // BASELINE: Err — 300 > i8::MAX (127); overflow returns an error.
+        assert!(result.is_err());
+    });
+}
+
+#[test]
+fn test_depythonize_int_300_as_u8_overflow() {
+    Python::attach(|py| {
+        let py_int = pythonize(py, &300i32).unwrap();
+        let result: Result<u8, _> = depythonize(&py_int);
+        // BASELINE: Err — 300 > u8::MAX (255); overflow returns an error.
+        assert!(result.is_err());
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Additional: f64::NAN → pythonize → depythonize::<f32>
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_f64_nan_to_f32_via_python() {
+    Python::attach(|py| {
+        let nan_f64 = f64::NAN;
+        let py_val = pythonize(py, &nan_f64).expect("pythonize failed");
+        let result: Result<f32, _> = depythonize(&py_val);
+        // BASELINE: Ok(f32::NAN) — f64 NaN → Python float nan → f32 NaN.
+        // NaN != NaN so equality is verified with is_nan().
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_nan());
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Additional: Rust () (unit) → Python → back as ()
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_unit_round_trip() {
+    Python::attach(|py| {
+        let py_val = pythonize(py, &()).expect("pythonize failed");
+        let result: Result<(), _> = depythonize(&py_val);
+        // BASELINE: Ok(()) — unit serializes to Python None; None correctly
+        // deserializes back to ().  Round-trip succeeds.
+        assert!(result.is_ok());
+    });
+}

--- a/tests/test_error_paths.rs
+++ b/tests/test_error_paths.rs
@@ -1,0 +1,139 @@
+use std::collections::HashMap;
+
+use pyo3::prelude::*;
+use pyo3::types::{PyBool, PyBytes, PyInt, PyList, PyString};
+use pythonize::{depythonize, pythonize};
+
+// ---------------------------------------------------------------------------
+// AC-1: Non-string map key (HashMap<i64, i32>) → pythonize
+// BASELINE: Ok — UNEXPECTED: the serializer does NOT reject integer keys;
+// Python dicts accept any hashable key natively.  DictKeyNotString is a
+// deserializer-side check (de.rs) and is never triggered during pythonize.
+// The informational error-message comment below would apply on the de side:
+// // assert!(err.to_string().contains("dict keys must have type str"));
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_pythonize_i64_key_map_is_ok() {
+    Python::attach(|py| {
+        let mut map: HashMap<i64, i32> = HashMap::new();
+        map.insert(1, 10);
+        map.insert(2, 20);
+        // BASELINE: Ok — pythonize produces a Python dict with integer keys;
+        // no error is returned by the serializer.
+        let result = pythonize(py, &map);
+        assert!(result.is_ok());
+    });
+}
+
+// ---------------------------------------------------------------------------
+// AC-2: Python str → depythonize::<i64> → Err
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_depythonize_py_str_as_i64_is_err() {
+    Python::attach(|py| {
+        let py_str = PyString::new(py, "hello");
+        let result: Result<i64, _> = depythonize(py_str.as_any());
+        assert!(result.is_err());
+    });
+}
+
+// ---------------------------------------------------------------------------
+// AC-3: Python bytes → depythonize::<String> → characterise actual behaviour
+// BASELINE: bytes successfully deserializes to String via serde_bytes-style
+// path — result depends on runtime; see comment below.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_depythonize_py_bytes_as_string() {
+    Python::attach(|py| {
+        let py_bytes = PyBytes::new(py, b"hello");
+        let result: Result<String, _> = depythonize(py_bytes.as_any());
+        // BASELINE: Err — bytes is not a str; depythonize returns an error when
+        // deserializing bytes as String because the serde string visitor
+        // requires UTF-8 text, not a bytes sequence.
+        assert!(result.is_err());
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Additional characterisation: Python int → depythonize::<String>
+// BASELINE: Err — an integer cannot be coerced to a Rust String by the
+// deserializer; it expects a Python str, not int.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_depythonize_py_int_as_string() {
+    Python::attach(|py| {
+        let py_int = PyInt::new(py, 42i64);
+        let result: Result<String, _> = depythonize(py_int.as_any());
+        // BASELINE: Err — int is not accepted as String; no silent coercion.
+        assert!(result.is_err());
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Additional characterisation: Python None → depythonize::<i64>
+// BASELINE: Err — None is not an integer; deserializer returns an error.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_depythonize_py_none_as_i64() {
+    Python::attach(|py| {
+        let py_none = py.None();
+        let result: Result<i64, _> = depythonize(py_none.bind(py));
+        // BASELINE: Err — None cannot deserialize as i64.
+        assert!(result.is_err());
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Additional characterisation: Python list → depythonize::<String>
+// BASELINE: Err — a sequence cannot deserialize as a bare String.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_depythonize_py_list_as_string() {
+    Python::attach(|py| {
+        let py_list = PyList::new(py, [1i32, 2, 3]).unwrap();
+        let result: Result<String, _> = depythonize(py_list.as_any());
+        // BASELINE: Err — list cannot deserialize as String.
+        assert!(result.is_err());
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Additional characterisation: Python bool → depythonize::<String>
+// BASELINE: Err — a Python bool is not a str; deserializer rejects it.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_depythonize_py_bool_as_string() {
+    Python::attach(|py| {
+        let py_bool = PyBool::new(py, true);
+        let result: Result<String, _> = depythonize(py_bool.as_any());
+        // BASELINE: Err — bool is not accepted as String.
+        assert!(result.is_err());
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Additional characterisation: HashMap<bool, i32> → pythonize
+// BASELINE: Ok — UNEXPECTED: same as i64 keys; the serializer converts bool
+// to Python bool and uses it as a dict key without error.  Python dicts
+// accept boolean keys natively (True/False are hashable).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_pythonize_bool_key_map_is_ok() {
+    Python::attach(|py| {
+        let mut map: HashMap<bool, i32> = HashMap::new();
+        map.insert(true, 1);
+        map.insert(false, 0);
+        // BASELINE: Ok — pythonize produces a Python dict with bool keys
+        // {True: 1, False: 0}; no error is returned by the serializer.
+        let result = pythonize(py, &map);
+        assert!(result.is_ok());
+    });
+}


### PR DESCRIPTION
﻿## Summary

Adds characterisation and error-path tests covering type-mismatch cases and asymmetric round-trip behaviours.

## Files added

**`tests/test_error_paths.rs`** (8 tests)
- `HashMap<i64, V>` serialized by `pythonize` -> `Ok` (unexpected: `DictKeyNotString` lives in the deserializer only; see note below)
- `HashMap<bool, V>` -> same root cause
- Python `str` -> `depythonize::<i64>` -> `Err`
- Python `bytes` -> `depythonize::<String>` -- characterised
- Python `None` / `list` -> `depythonize::<i64>` -> `Err`

**`tests/test_asymmetry.rs`** (16 tests)
- `BTreeMap` content equality after round-trip
- `f32` precision: `MIN_POSITIVE`, `PI`, subnormal -- all survive; `// BASELINE:` comments note the f64 widening
- `char` length guard: `"ab"` and `"hello"` -> `Err` (correct rejection)
- `bool` -> `i64`/`i32`: `Ok(1)`/`Ok(0)` -- Python `bool` subclasses `int`
- `i64(300)` -> `i8`/`u8` overflow -> `Err` (no silent truncation)
- `f64::NAN` -> Python -> `f32`: `Ok(NaN)` -- NaN survives narrowing
- Unit `()` round-trip: `Ok`

## Notable findings

**Non-string map keys serialize without error** (`HashMap<i64, V>`, `HashMap<bool, V>`): `pythonize` produces a Python dict with non-string keys -- the `DictKeyNotString` check exists only in the deserializer. The round-trip breaks silently on the deserialization side. Tests assert the observed `Ok` and are flagged `// BASELINE: UNEXPECTED`.

## Test approach

Plain `#[test]` functions using `Python::attach`. No new dev-dependencies. Characterisation tests use `// BASELINE:` comments; surprising cases are additionally flagged `// BASELINE: UNEXPECTED`.
